### PR TITLE
Labelling responsiveness

### DIFF
--- a/analysis/classification/main.py
+++ b/analysis/classification/main.py
@@ -1,3 +1,8 @@
+#from pyinstrument import Profiler
+
+#profiler = Profiler()
+#profiler.start()
+
 import pandas as pd
 import sqlite3
 from youtube_transcript_api import YouTubeTranscriptApi
@@ -27,7 +32,7 @@ st.set_page_config(page_title='Active Learning Frontend',layout='wide')
 token = simple_auth()
 if token == '':
     st.stop()
-connect_to_db(token)
+st.session_state['bq_client'] = connect_to_db(token)
 #token = 'admin'
 ########################### DataBase Management ################################
 
@@ -68,3 +73,6 @@ if operation == 'Get Stats':
     if token == 'admin':
         display_labelling_progress()
 
+#profiler.stop()
+
+#profiler.print()

--- a/analysis/classification/utils/db_functions.py
+++ b/analysis/classification/utils/db_functions.py
@@ -235,8 +235,6 @@ def assign_sample_data_to_label(token='admin'):
 
 
 def get_datapoint_to_label(labeler):
-    if "data_to_label" in st.session_state:
-    else:
     if "data_to_label" in st.session_state and len(st.session_state.data_to_label) >= 5:
         # if we have data in the cache, no need to fetch more data
         pass

--- a/analysis/classification/utils/db_functions.py
+++ b/analysis/classification/utils/db_functions.py
@@ -103,11 +103,17 @@ def get_table(table, schema):
 @st.cache(hash_funcs={bigquery.client.Client: id})
 def connect_to_db(user):
     if user == 'admin':
-        credentials = pydata_google_auth.get_user_credentials(
-            ['https://www.googleapis.com/auth/bigquery'],
-            use_local_webserver=True,
-        )
+        #credentials = pydata_google_auth.get_user_credentials(
+        #    ['https://www.googleapis.com/auth/bigquery'],
+        #    use_local_webserver=True,
+        #)
 
+        #project_id = "regrets-reporter-dev"
+        #bq_client = bigquery.Client(
+        #    project=project_id, credentials=credentials)
+        credentials = service_account.Credentials.from_service_account_info(
+            dict(**st.secrets.ranu_testing), scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
         project_id = "regrets-reporter-dev"
         bq_client = bigquery.Client(
             project=project_id, credentials=credentials)
@@ -279,7 +285,7 @@ def get_datapoint_to_label(labeler):
         else:
             st.session_state.data_to_label = pd.concat([st.session_state.data_to_label, new_data])
         st.session_state.fetch_job = None
-    res = st.session_state.data_to_label.iloc[0:1]
+    res = st.session_state.data_to_label.head(1)
     st.session_state.data_to_label = st.session_state.data_to_label[1:]
     if len(res) == 0:
         st.error("NO DATA AVAILABLE TO LABEL")


### PR DESCRIPTION
Add caching to make sure that labelling workflow is responsive.  We now pull multiple pairs to label at once and get more before we need them.  Also create another thread to push labelled pairs to backend.