### PR TITLE
Add a unique prefix to injected class names

### DIFF
--- a/source/content/button.ts
+++ b/source/content/button.ts
@@ -51,7 +51,7 @@ function generateButtonId(videoId: string) {
 const getMainVideoId = () => document.getElementsByTagName('ytd-watch-flexy')[0].getAttribute('video-id');
 
 function clearInjectedButtons() {
-	const elements = document.getElementsByClassName('injected-btn');
+	const elements = document.getElementsByClassName('mrr-injected-btn');
 	for (const element of Array.from(elements)) {
 		element.remove();
 	}
@@ -102,7 +102,7 @@ function injectButton(
 ) {
 	const videoId = getVideoId();
 	const lastChild = parentNode.lastElementChild;
-	const hasInjectedButton = lastChild && lastChild.classList.contains('injected-btn');
+	const hasInjectedButton = lastChild && lastChild.classList.contains('mrr-injected-btn');
 	if (!videoId) {
 		log('no video id found');
 		if (hasInjectedButton) {
@@ -124,7 +124,7 @@ function injectButton(
 	const btn = document.createElement('div');
 	btn.id = buttonId;
 	btn.dataset.hash = injectionHash;
-	btn.className = 'injected-btn';
+	btn.className = 'mrr-injected-btn';
 
 	const label = document.createElement('span');
 	label.innerText = 'Stop Recommending';

--- a/source/content/content.css
+++ b/source/content/content.css
@@ -3,7 +3,7 @@
 @import '../common/fonts/changa.css';
 @import '../common/fonts/nunito-sans.css';
 
-body[dir='rtl'] .injected-btn {
+body[dir='rtl'] .mrr-injected-btn {
 	top: 5px;
 	right: 5px;
 	left: auto;
@@ -14,7 +14,7 @@ body[dir='rtl'] .injected-btn {
 	}
 }
 
-.injected-btn {
+.mrr-injected-btn {
 	visibility: hidden;
 	position: absolute;
 	color: #fff;
@@ -91,7 +91,7 @@ body[dir='rtl'] .injected-btn {
 	}
 }
 
-.ytp-fullscreen .injected-btn {
+.ytp-fullscreen .mrr-injected-btn {
 	display: none;
 }
 
@@ -100,17 +100,17 @@ ytd-compact-video-renderer:hover,
 ytd-player:hover,
 ytd-thumbnail:hover,
 #video-preview-container {
-	& .injected-btn {
+	& .mrr-injected-btn {
 		visibility: visible;
 	}
 }
 
-#video-preview-container .injected-btn {
+#video-preview-container .mrr-injected-btn {
 	top: 20px;
 	left: 20px;
 }
 
-.injected-modal {
+.mrr-injected-modal {
 	direction: ltr;
 	min-width: 400px;
 	width: 50%;
@@ -128,15 +128,15 @@ ytd-thumbnail:hover,
 		text-decoration: none;
 	}
 
-	& .header {
-		& #icon {
+	& .mrr-header {
+		& .mrr-icon {
 			width: 20px;
 			height: 20px;
 			background: url('data-url:../assets/face.svg') no-repeat;
 			margin: 0 16px;
 		}
 
-		& #close {
+		& .mrr-close {
 			cursor: pointer;
 			width: 26px;
 			height: 26px;
@@ -157,14 +157,14 @@ ytd-thumbnail:hover,
 		align-items: center;
 	}
 
-	& .panel {
+	& .mrr-panel {
 		margin: 16px;
 		padding: 32px;
 		background: #fff;
 		font-family: 'Nunito Sans';
 		font-size: 16px;
 
-		& .label {
+		& .mrr-label {
 			padding: 5px 0;
 			font-size: 16px;
 			font-weight: 600;
@@ -172,12 +172,12 @@ ytd-thumbnail:hover,
 			line-height: 14px;
 		}
 
-		& .message {
+		& .mrr-message {
 			padding-top: 10px;
 		}
 	}
 
-	& .footer {
+	& .mrr-footer {
 		background: #fff;
 		margin: -15px 16px 16px;
 		padding: 32px;
@@ -219,7 +219,7 @@ ytd-thumbnail:hover,
 	}
 }
 
-.overlay {
+.mrr-overlay {
 	width: 100%;
 	height: 100%;
 	position: fixed;

--- a/source/content/modal.tsx
+++ b/source/content/modal.tsx
@@ -57,18 +57,18 @@ export function Modal() {
 	}
 	return (
 		<div>
-			<div className="overlay" />
-			<div className="injected-modal">
-				<div className="header">
-					<div id="icon" />
+			<div className="mrr-overlay" />
+			<div className="mrr-injected-modal">
+				<div className="mrr-header">
+					<div className="mrr-icon" />
 					<span>Mozilla RegretsReporter</span>
-					<div id="close" onClick={close} />
+					<div className="mrr-close" onClick={close} />
 				</div>
 				{isSubmitted ? (
 					<>
-						<div className="panel">
-							<div className="label">Thank you for your submission.</div>
-							<div className="message">
+						<div className="mrr-panel">
+							<div className="mrr-label">Thank you for your submission.</div>
+							<div className="mrr-message">
 								If you believe that the content you identified in this submission constitutes abuse under YouTube's
 								policies, please report it directly to YouTube via its{' '}
 								<a href={abuseReportingPlatformUrl} target="_blank" rel="noreferrer">
@@ -77,7 +77,7 @@ export function Modal() {
 								.
 							</div>
 						</div>
-						<div className="footer">
+						<div className="mrr-footer">
 							Do you have feedback about the RegretsReporter? We would love to hear it.{' '}
 							<a href={extensionFeedbackUrl} target="_blank" rel="noreferrer">
 								Send us feedback
@@ -86,8 +86,8 @@ export function Modal() {
 						</div>
 					</>
 				) : (
-					<div className="panel">
-						<div className="label">
+					<div className="mrr-panel">
+						<div className="mrr-label">
 							Please tell us more about your experience. Why do you want YouTube to stop recommending this content to
 							you?
 						</div>


### PR DESCRIPTION
Fixes #59 and other potential errors caused by stylesheet classname collisions.
Would have been optimal to use CSS modules for this, but unfortunately that doesn't play well with the Parcel WebExt bundling.